### PR TITLE
fix: force add dist directory in workflows to handle gitignore

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -64,13 +64,13 @@ jobs:
             echo "release_version=$VERSION" >> $GITHUB_OUTPUT
           fi
       
-      # Commit the built files if they've changed
+      # Force add dist directory (even if it's in .gitignore)
       - name: Commit built files
         if: steps.version-check.outputs.new_release_required == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add dist/
+          git add -f dist/
           if git diff --staged --quiet; then
             echo "No changes to commit."
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Build action
         run: npm run build
       
-      # Commit the built files if they've changed
+      # Commit the built files if they've changed (using -f to force add ignored files)
       - name: Commit built files
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add dist/
+          git add -f dist/
           git diff --quiet && git diff --staged --quiet || git commit -m "Build dist files for release ${{ github.event.release.tag_name }}"
           git push
       


### PR DESCRIPTION
- Add -f flag to git add commands in GitHub Actions workflows
- Ensure built dist files are committed even if they're in .gitignore
- Update both auto-release and publish workflows for consistency

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
