### PR TITLE
chore: add Claude Code project workflow (CLAUDE.md, skills, hooks)

### DIFF
--- a/.claude/hooks/actionlint-check.sh
+++ b/.claude/hooks/actionlint-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# PostToolUse hook: lints changed GitHub Actions workflow/action files with actionlint.
+# Reads the tool call JSON from stdin, does nothing for files outside .github/workflows or
+# .github/actions/**/action.yml, otherwise runs actionlint and surfaces findings back to Claude.
+set -u
+
+input="$(cat)"
+file="$(printf '%s' "$input" | jq -r '.tool_response.filePath // .tool_input.file_path // empty' 2>/dev/null)"
+[ -z "$file" ] && exit 0
+
+# Must be a .yml/.yaml file that lives under a .github/ directory (workflow or
+# composite/reusable action), not just a path that happens to contain ".github".
+case "$file" in
+  *.yml|*.yaml) ;;
+  *) exit 0 ;;
+esac
+
+case "$file" in
+  .github/workflows/*|*/.github/workflows/*) ;;
+  .github/actions/*/action.yml|.github/actions/*/action.yaml) ;;
+  */.github/actions/*/action.yml|*/.github/actions/*/action.yaml) ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$file" ] || exit 0
+
+CACHE_DIR="${HOME:-/tmp}/.cache/actionlint"
+VERSION="1.7.7"
+BIN=""
+
+if command -v actionlint >/dev/null 2>&1; then
+  BIN="actionlint"
+elif [ -x "$CACHE_DIR/actionlint" ]; then
+  BIN="$CACHE_DIR/actionlint"
+elif [ -x "$CACHE_DIR/actionlint.exe" ]; then
+  BIN="$CACHE_DIR/actionlint.exe"
+else
+  mkdir -p "$CACHE_DIR" 2>/dev/null
+
+  uname_s="$(uname -s 2>/dev/null || echo unknown)"
+  uname_m="$(uname -m 2>/dev/null || echo unknown)"
+
+  case "$uname_s" in
+    Darwin) plat="darwin" ;;
+    MINGW*|MSYS*|CYGWIN*) plat="windows" ;;
+    Linux) plat="linux" ;;
+    *) plat="" ;;
+  esac
+
+  case "$uname_m" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) arch="" ;;
+  esac
+
+  if [ -n "$plat" ] && [ -n "$arch" ] && command -v curl >/dev/null 2>&1; then
+    if [ "$plat" = "windows" ]; then
+      url="https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_windows_${arch}.zip"
+      zip="$CACHE_DIR/actionlint.zip"
+      if curl -fsSL "$url" -o "$zip" 2>/dev/null && command -v unzip >/dev/null 2>&1; then
+        (cd "$CACHE_DIR" && unzip -oq actionlint.zip actionlint.exe 2>/dev/null)
+        rm -f "$zip"
+      fi
+      [ -x "$CACHE_DIR/actionlint.exe" ] && BIN="$CACHE_DIR/actionlint.exe"
+    else
+      url="https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_${plat}_${arch}.tar.gz"
+      if curl -fsSL "$url" 2>/dev/null | tar xz -C "$CACHE_DIR" actionlint 2>/dev/null; then
+        chmod +x "$CACHE_DIR/actionlint" 2>/dev/null
+        BIN="$CACHE_DIR/actionlint"
+      fi
+    fi
+  fi
+fi
+
+if [ -z "$BIN" ]; then
+  msg="actionlint is not installed and could not be auto-downloaded, so $file was not linted. "
+  msg="$msg Install it manually: macOS -> 'brew install actionlint'; Windows/Linux -> download a binary from https://github.com/rhysd/actionlint/releases and put it on PATH or at $CACHE_DIR/actionlint(.exe)."
+  jq -n --arg m "$msg" '{systemMessage: $m}'
+  exit 0
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+config_file="$script_dir/../actionlint.yaml"
+lint_args=()
+[ -f "$config_file" ] && lint_args+=(-config-file "$config_file")
+
+output="$("$BIN" "${lint_args[@]}" "$file" 2>&1)"
+if [ -n "$output" ]; then
+  jq -n --arg file "$file" --arg out "$output" \
+    '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: ("actionlint found issues in \($file):\n" + $out)}}'
+fi
+exit 0

--- a/.claude/hooks/protect-branches.sh
+++ b/.claude/hooks/protect-branches.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PreToolUse hook: blocks git commit/push while checked out on a protected branch.
+# Enforces the CLAUDE.md rule: never commit directly to dev, staging, or main.
+set -u
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+[ -z "$branch" ] && exit 0
+
+case "$branch" in
+  dev|staging|main)
+    jq -n --arg branch "$branch" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: ("Blocked: cannot commit or push directly to protected branch \"" + $branch + "\". Create a branch (fix/…, feat/…, chore/…) and open a PR targeting dev instead.")
+      }
+    }'
+    ;;
+  *) exit 0 ;;
+esac

--- a/.claude/hooks/ts-typecheck.sh
+++ b/.claude/hooks/ts-typecheck.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PostToolUse hook: type-checks the touched project with `tsc --noEmit` after editing a .ts/.tsx file.
+# Scoped to frontend-backoffice, frontend-portal, and backend-chatbot, the three TypeScript projects in this repo.
+set -u
+
+input="$(cat)"
+file="$(printf '%s' "$input" | jq -r '.tool_response.filePath // .tool_input.file_path // empty' 2>/dev/null)"
+[ -z "$file" ] && exit 0
+
+case "$file" in
+  *.ts|*.tsx) ;;
+  *) exit 0 ;;
+esac
+
+project=""
+case "$file" in
+  frontend-backoffice/*|*/frontend-backoffice/*) project="frontend-backoffice" ;;
+  frontend-portal/*|*/frontend-portal/*) project="frontend-portal" ;;
+  backend-chatbot/*|*/backend-chatbot/*) project="backend-chatbot" ;;
+  *) exit 0 ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$repo_root" ] && exit 0
+project_dir="$repo_root/$project"
+[ -d "$project_dir/node_modules" ] || exit 0
+
+output="$(cd "$project_dir" && npx --no-install tsc --noEmit 2>&1)"
+if [ -n "$output" ]; then
+  jq -n --arg project "$project" --arg out "$output" \
+    '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: ("tsc --noEmit found issues in \($project):\n" + $out)}}'
+fi
+exit 0

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,22 @@
       "Bash(npm --version)",
       "Bash(npm test)",
       "Bash(find:*)",
-      "Bash(cat:*)"
+      "Bash(cat:*)",
+      "Bash(git symbolic-ref *)",
+      "Bash(git ls-remote *)",
+      "Bash(npm -g config get prefix)",
+      "Read(//home/nelson/.claude/**)",
+      "Read(//home/nelson/**)",
+      "Bash(env)",
+      "Bash(gh issue *)",
+      "Bash(gh pr *)",
+      "Bash(git -C /home/nelson/wsl_workspaces/git_wearemiew/yml-change-webhook-trigger status .claude/skills --short)",
+      "Bash(git -C /home/nelson/wsl_workspaces/git_wearemiew/yml-change-webhook-trigger ls-files .claude/skills)",
+      "Bash(git -C /home/nelson/wsl_workspaces/git_wearemiew/yml-change-webhook-trigger check-ignore -v .claude/settings.local.json)",
+      "Read(//etc/claude-code/**)",
+      "Bash(git -C /home/nelson/wsl_workspaces/git_wearemiew/yml-change-webhook-trigger status --short)",
+      "Bash(grep -v \"/skills$\\\\|/agents$\")",
+      "Bash(git restore *)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: bug
+description: Turn a bug report into a GitHub issue — reproduction steps, expected vs actual behavior, root cause if known, and acceptance criteria (no longer reproduces, plus a regression test). Adds it as a child issue of an in-flight feature's epic if the affected code is in that feature's scope; otherwise creates a standalone `bug`-labeled issue for `build` to pick up directly off `dev`. Use when the user reports something broken, a bug, a regression, or an error — not for new feature requests (use `to-prd` for those).
+allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue create:*), Bash(gh issue edit:*), Bash(gh repo view:*)
+---
+
+Turn a bug report into a single actionable issue. This is deliberately lighter than the feature pipeline (`to-prd` → `grill-me` → `feature` → `to-issues`) — a bug doesn't need a PRD, a ballpark estimate, or design sign-off. It needs a clear repro, a likely cause, and a place to attach the fix.
+
+## 1. Gather the report
+
+Pull reproduction steps, expected vs actual behavior, and any error/stack trace from the conversation.
+
+## 2. Explore for the likely cause
+
+Read the parts of the codebase the symptom points to — do this before deciding what's still missing, since exploring often answers questions you'd otherwise have to ask (e.g. an error message matches one specific code path, or a recent commit/PR touched exactly this area). Identify the probable root cause and which top-level project directory it lives in. Do not fix anything here — this skill only files the issue, `build` implements the fix.
+
+If, after exploring, critical details are still missing (how to reproduce it, what was expected), ask rather than inventing plausible-sounding repro steps — a bug issue with a guessed repro wastes whoever picks it up. If exploring turned up a likely cause or a specific reproduction path, lead with that as your best guess for the user to confirm rather than asking from scratch.
+
+## 3. Check for an in-flight feature
+
+Search open issues labeled `epic` (`gh issue list --label epic --state open`). If the affected code falls within one of those features' scope (its slices touch the same area), this bug belongs there as a child issue — it should branch from that feature's integration branch like any other slice, not from `dev`. Otherwise, it's a standalone bug.
+
+## 4. Create the issue
+
+```bash
+gh issue create --title "Bug: TITLE" --body "BODY" --label "bug"
+```
+
+<issue-template>
+
+## What's broken
+
+One or two sentences on the symptom, from the user's perspective.
+
+## Steps to reproduce
+
+1. Step 1
+2. Step 2
+
+## Expected vs actual
+
+- Expected: ...
+- Actual: ...
+
+## Root cause
+
+What you found during exploration, if you found it. State "Unknown — needs investigation during `build`" rather than guessing if you didn't find it.
+
+## Acceptance criteria
+
+- [ ] The reproduction steps above no longer trigger the bug
+- [ ] A regression test covers this case using the affected directory's documented test framework (see its `CLAUDE.md`)
+
+## Severity
+
+Low / Medium / High / Critical — how much user impact, not how hard the fix looks.
+
+---
+_(if part of an in-flight feature)_ Part of #EPIC · integration branch: `feat/<feature-branch>`
+
+</issue-template>
+
+If this bug is a child of an epic, also edit the epic's body to list it under the appropriate layer group, same as `to-issues` does for a new slice.
+
+## 5. Report
+
+Output the issue URL and whether it's standalone or a child of an existing epic. Tell the user the next step is running `build` against it — `build` will branch it off `dev` (`fix/<slug>`) if standalone, or off the feature's integration branch if it's a child issue.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: build
+description: Implement a GitHub issue end-to-end — draft a plan, get user approval/refinement, implement it, then add tests. Works for both a feature slice (produced by `to-issues`) and a standalone bug fix (produced by the `bug` skill). Use when user wants to build, implement, or pick up a GitHub issue, ticket, or bug.
+allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh repo view:*), Bash(git checkout:*), Bash(git branch:*), Bash(git fetch:*), Bash(git pull:*)
+---
+
+Implement a single GitHub issue — a feature slice from `to-issues`, or a standalone bug from the `bug` skill — through four stages: **plan → approve/refine → implement → test**. Never skip straight to implementation.
+
+A feature slice always branches from that feature's **integration branch** (created by the `feature` kickoff skill), never from `dev` directly — backend, frontend, and devops slices for the same feature all branch off, and merge back into, that shared integration branch, and only the integration branch merges into `dev`. A standalone bug fix branches directly from `dev` instead, since there's no feature it belongs to. See step 1b for how to tell which case you're in.
+
+## 1. Gather the issue
+
+If the user passed an issue number or URL:
+
+```bash
+gh issue view NUMBER --json title,body,labels,url
+```
+
+If not, run `gh issue list` yourself first and present the most relevant open candidates (matching what's currently under discussion, if anything) rather than asking a blind "which issue?". Read the issue's "What to build", "Acceptance criteria", and "Blocked by" sections. If it's blocked by an open issue, tell the user and confirm whether to proceed anyway.
+
+## 1b. Identify the base branch
+
+Which branch to base this on depends on whether the issue belongs to a feature or is a standalone bug:
+
+- **Feature slice** (backend/frontend/devops label, linked to an epic): the tracking/epic issue that this issue links to (or is referenced by) records the integration branch name — check the issue body and its parent. If it isn't recorded there, run `git branch -a --list 'feat/*'` and check open `epic` issues for a plausible match before asking the user to name the feature branch outright. Do not assume `dev`. If the integration branch doesn't exist yet, stop and tell the user to run the `feature` kickoff skill first.
+- **Standalone bug** (`bug` label, no epic reference — typically produced by the `bug` skill): base directly off `dev`. That's what makes it standalone rather than a feature slice; there's no integration branch to wait on.
+
+Confirm the base branch exists on the remote before branching from it:
+
+```bash
+git fetch origin && git branch -a --list '*<base>*'
+```
+
+## 2. Explore
+
+Read the parts of the codebase the issue touches. Identify existing patterns, conventions, and the files that will change. Do not write any code yet.
+
+Identify which top-level project directory (or directories) the issue's files live under and **read that directory's own `CLAUDE.md`** if it has one — this repo is polyglot, there is no single "run the tests" command that works everywhere, so each project documents its own real test/lint/type-check commands and gotchas there. If a touched directory has no `CLAUDE.md` (new package, or it hasn't been documented yet), check its `package.json`/`.csproj`/CI config yourself, treat what you find as equally authoritative, and tell the user that directory is missing a `CLAUDE.md` so they can decide whether to add one.
+
+If an issue spans multiple project directories, read each touched directory's `CLAUDE.md` — don't assume one project's conventions apply to another.
+
+## 3. Plan (requires approval)
+
+Enter plan mode. A plan that just restates the acceptance criteria isn't a plan — it has to show the actual shape of the change before a single line of code is written. Use this structure:
+
+<plan-template>
+
+# Plan: <Issue Title>
+
+## Approach
+
+One paragraph: the overall approach, and why — especially if there was a real alternative you considered and rejected (e.g. extending an existing entity vs. adding a new one).
+
+## Acceptance criteria → implementation mapping
+
+One entry per acceptance criterion from the issue:
+- **Criterion**: <text from the issue>
+  - **Change**: which specific files/functions/components/entities implement this
+  - **Test**: which test (naming it, not just "add a test") verifies it, using the framework documented in the touched directory's `CLAUDE.md`
+
+## File-by-file changes
+
+- `path/to/file.ext` — what changes here and why
+- `path/to/new_file.ext` (new) — what it does and why it's a new file rather than an addition to an existing one
+
+## Data model / API / contract changes
+
+Any schema, migration, DTO, or API contract changes, named explicitly (field names, types, endpoint shapes) — not "update the model," the actual shape of the update. If there are none, say so explicitly rather than omitting the section.
+
+## Sequencing
+
+The order you'll implement in, especially where one step blocks another (e.g. schema before endpoint before UI).
+
+## Assumptions & open questions
+
+Anything you're inferring rather than something the issue/PRD actually states — flag it here instead of guessing silently and finding out you guessed wrong mid-implementation.
+
+## Out of scope
+
+Anything adjacent this plan deliberately does not do, so the reviewer isn't surprised by an omission later.
+
+</plan-template>
+
+Ground the "File-by-file" and "Data model" sections in what you found during step 2's exploration — name the actual entities/files/types that exist today, not generic descriptions, so the reviewer can tell this plan is based on the real codebase rather than a plausible-sounding guess.
+
+Present the plan for approval. If the user requests changes, revise and re-present — repeat until they approve. Do not proceed to implementation on an unapproved or partially-approved plan.
+
+## 4. Branch
+
+Once the plan is approved, cut a branch from the base identified in step 1b — the naming convention depends on which case you're in:
+
+- **Feature slice**: from the integration branch, never from `dev` directly. Pattern is `feat/<feature-branch>/<task>` — the task slug should describe the slice well enough on its own (e.g. `endpoint-export-csv`, `organizations-page`) that an explicit layer code isn't needed. Example: feature branch `referralcodes` + a backend CSV export endpoint → `feat/referralcodes/endpoint-export-csv`; its frontend counterpart (a button triggering that export) → `feat/referralcodes/button-csv-export`.
+- **Standalone bug**: from `dev` directly, named `fix/<slug>` — matching the `fix/` branch prefix this repo's PR auto-labeler already expects for the `bug` label.
+
+```bash
+git fetch origin && git checkout <base-branch> && git pull && git checkout -b <new-branch-name>
+```
+
+## 5. Implement
+
+Follow the approved plan step by step. Match existing code conventions found during exploration.
+
+As you write code, run the type-check and lint commands documented in the touched directory's `CLAUDE.md` (or the ones you found yourself, if it had none) after each meaningful change rather than waiting until the end. When they surface a type mismatch, compilation error, or lint failure, read the trace and self-correct immediately — don't stop to ask about something the tools already told you how to fix. The only reason to pause and check with the user is if reality diverges from the plan in a way that changes **scope** (a requirement turns out to need a different approach, an acceptance criterion can't be met as planned, an assumption from the plan was wrong) — mechanical errors are yours to fix autonomously, scope changes are the user's call.
+
+## 6. Test
+
+For each acceptance criterion, add or update a test that exercises it using the test framework and conventions documented in that directory's `CLAUDE.md`. Don't introduce a different framework or invent a layer of testing (e.g. unit tests) that isn't part of that project's documented convention (e.g. E2E-only).
+
+Run the full test command documented for that directory (not a partial/single-test run) and treat failures the same way as compiler/lint errors in step 5: read the failure, fix the code (or the test, if the test was wrong), and re-run — iterate autonomously until the suite passes rather than surfacing the first failure to the user. If that directory's `CLAUDE.md` notes that CI doesn't gate on tests, treat this step as the real enforcement and don't skip or shortcut it because "the diff looks right."
+
+If the touched directory's `CLAUDE.md` (or your own check) says it has no test framework, don't silently skip this step or silently add a framework — tell the user in your final report that the acceptance criteria could only be verified manually, and ask whether to scaffold minimal testing now or file it as separate follow-up.
+
+Once done, go through the acceptance criteria checklist explicitly and confirm each one is verifiably met (by test, or by manual check if the criterion isn't testable in code).
+
+## 7. Handoff
+
+This skill's job ends with working, tested code left uncommitted in the working tree — it does not commit, push, or open a PR under any circumstances, approval or not. Committing, pushing, and opening the PR are for the user (or a separate step) to do. Before that PR opens, suggest running the `qa` skill against this slice — it catches security/performance/maintainability issues and deviations from the acceptance criteria that this skill's own step 6 doesn't check for.
+
+Report to the user:
+- The acceptance-criteria checklist with how each one was verified.
+- The files changed (a `git status`/`git diff --stat` summary is enough, don't dump the full diff unless asked).
+- A suggested commit message in Conventional Commits format referencing the issue (e.g. `Closes #NUMBER` in the body), for them to use if they want it.
+- A reminder of where the PR should target when they open it: the integration branch (`--base <feature-branch>`) for a feature slice, or `dev` directly for a standalone bug fix — either way with labels matching the changed paths and branch prefix per `.github/labeler.yml`, and if this is a frontend slice blocked by its backend counterpart, noting that dependency in the PR body.

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: feature
+description: Kick off a new feature right after its PRD is grilled — create its shared integration branch off dev, a tracking (epic) issue, and a design-tracking issue that gates dev ticket creation. Use when starting a new feature or setting up a feature branch, before any backend/frontend/devops tickets exist.
+allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue create:*), Bash(gh issue edit:*), Bash(gh repo view:*), Bash(git checkout:*), Bash(git branch:*), Bash(git fetch:*), Bash(git pull:*), Bash(git push:*)
+---
+
+Set up a new feature so design, backend, frontend, and devops can all collaborate on it. A feature gets **one shared integration branch** cut from `dev`; every slice branch (`feat/<feature-branch>/<task>`) is cut from — and merged back into — that integration branch. Only the integration branch merges into `dev`.
+
+This skill runs once per feature, right after `grill-me`'s ballpark is approved — **before** `to-issues` and before any dev tickets exist. It produces three things: the integration branch, a tracking (epic) issue, and a design-tracking issue. Backend/frontend/devops tickets don't exist yet at this point; `to-issues` adds them to the epic later, once design signs off. Keeping design on its own issue (instead of a placeholder paragraph in the PRD) makes it assignable, closeable, and visible on the same board as everything else.
+
+## 1. Identify the feature
+
+Before asking anything, check what the repo already tells you: if no PRD reference was given, look at recent discussions in the "PRD" category for a plausible match, and check existing `epic` issues / `feat/*` branches so a proposed slug doesn't collide with one already in flight.
+
+Get the feature name (short kebab-case slug, e.g. `checkout`) and the PRD it's based on — a Discussions URL/number if the user gives one, otherwise whatever PRD content is already in the conversation context. If exploring surfaced a likely PRD or slug, lead with that as your suggested answer rather than asking blind. Confirm both with the user before proceeding.
+
+## 2. Create the integration branch
+
+Cut it from an up-to-date `dev`. Name it `feat/<feature-branch>`.
+
+```bash
+git fetch origin && git checkout dev && git pull && git checkout -b feat/<feature-branch>
+```
+
+Do not push without asking (per root `CLAUDE.md`). Once the user approves, publish it so slices can branch from the remote:
+
+```bash
+git push -u origin feat/<feature-branch>
+```
+
+## 3. Create the design-tracking issue
+
+Create this before the epic, so the epic can reference its real issue number. This is what replaces the old "designer edits a placeholder paragraph in the PRD" approach — design work gets a real, assignable, closeable issue like everything else, and it's what `to-issues` waits on before generating dev tickets.
+
+```bash
+gh issue create --title "Design: <Feature Name>" --body "BODY" --label "design"
+```
+
+<design-issue-template>
+
+## What's needed
+
+Client-approved Figma frame link(s) covering the user stories in the PRD (link the PRD discussion here). List the specific screens/states expected, derived from the PRD's user stories.
+
+## Figma frames
+
+_(designer: paste frame links here, one per screen/state, then close this issue)_
+
+## Blocks
+
+`to-issues` will not generate backend/frontend/devops tickets for this feature until this issue is closed with real Figma links attached.
+
+</design-issue-template>
+
+## 4. Create the tracking (epic) issue
+
+Create one issue that is the home base for the feature. Its body records the integration branch name (so `build` and `to-issues` can find it) and checklists the slices grouped by layer — Design starts populated with the real issue number from step 3; Backend/Frontend/DevOps start empty since `to-issues` fills those in once design signs off.
+
+```bash
+gh issue create --title "Feature: <Feature Name>" --body "BODY" --label "epic"
+```
+
+<epic-template>
+
+## Summary
+
+One paragraph: what this feature delivers, from the user's perspective. Link the PRD discussion if there is one.
+
+## Integration branch
+
+`feat/<feature-branch>` — all slice branches for this feature are cut from and merged into this branch. It merges to `dev` only when the whole feature is complete and has passed integration QA.
+
+## Slices
+
+Design:
+- [ ] #NN — Design: <Feature Name>
+
+Backend:
+- _(added by `to-issues` once the design issue above is closed)_
+
+Frontend:
+- _(added by `to-issues` once the design issue above is closed)_
+
+DevOps:
+- _(added by `to-issues` once the design issue above is closed)_
+
+## Definition of done
+
+- [ ] All slices merged into `feat/<feature-branch>`
+- [ ] Feature validated end-to-end against the PRD acceptance criteria (run the `qa` skill in feature-level mode against this branch)
+- [ ] Integration branch merged into `dev`
+
+</epic-template>
+
+## 5. Link the design issue back to the epic
+
+```bash
+gh issue edit NN --body "$(updated body with: 'Part of #EPIC · integration branch: feat/<feature-branch>')"
+```
+
+## 6. Report
+
+Output to the user: the integration branch name, the epic issue URL, and the design issue URL. Tell them the next step is getting the design issue closed with real Figma frames, after which `to-issues` can be run to generate backend/frontend/devops tickets against this same epic.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: grill-me
+description: >
+  Facilitate a whole-team sync (PM, Frontend, Backend, DevOps, Design) to stress-test a PRD, 
+  flag multi-layer constraints, and produce a high-level ballpark estimate.
+allowed-tools: Bash(gh api graphql:*), Bash(gh repo view:*)
+---
+
+You are an automated technical architect facilitator. Before asking anything, explore the repo to understand the current state of the product — what features exist, how they're structured, and where they interact.
+
+Interview the team about the proposed feature, one question at a time, focused on three things:
+1. What is the goal of this feature and what outcome it should achieve.
+2. **Multi-layer Dependencies:** What database schemas (Backend), interface components (Frontend), or infrastructure/routing adjustments (DevOps) are required to build this?
+3. **UX & Edge Cases:** What empty states, loading sequences, or fallback experiences must the designer account for during the upcoming design phase?
+
+Use `AskUserQuestion` for every question. Provide 2–4 options with your recommended answer first (append "(Recommended)" to its label) — base the options and your recommendation on what you actually found exploring the repo, not generic defaults, so the team is reacting to something concrete rather than filling in a blank form. The user can always pick "Other".
+
+If a question can be answered by exploring the codebase, explore instead of asking.
+
+## When the interview is complete
+
+Compile a structured Markdown report of the full decision tree (every question, your recommended answer, and the chosen answer) along with a Rough Order of Magnitude (ROM) ballpark estimate, and post it to GitHub Discussions:
+
+1. Run `gh repo view --json nameWithOwner` to get owner and repo name.
+2. Query discussion categories and find "Cooking Grill" by name:
+```bash
+gh api graphql -f query='query($owner:String!,$repo:String!){
+  repository(owner:$owner,name:$repo){
+    id
+    discussionCategories(first:20){nodes{id name}}
+  }
+}' -f owner="OWNER" -f repo="REPO"
+```
+3. Create the discussion using the repository id and the "Cooking Grill" category id from the query above:
+```bash
+gh api graphql -f query='mutation($repoId:ID!,$catId:ID!,$title:String!,$body:String!){
+  createDiscussion(input:{repositoryId:$repoId,categoryId:$catId,title:$title,body:$body}){
+    discussion { url }
+  }
+}' -f repoId="REPO_ID" -f catId="CATEGORY_ID" -f title="TITLE" -f body="BODY"
+```
+4. If the interview started from a PRD discussion, link back to it in the report so the client can trace the estimate to its source, and report the new discussion URL to the user.
+
+## Report template
+
+The ROM section goes **first**, above the decision tree — the client needs to approve scope/timeline before anyone reads the technical detail underneath it.
+
+```markdown
+# Grill: [Feature Name]
+
+## Rough Order of Magnitude (ROM)
+
+> ⚠️ Ballpark only, not a commitment. Real estimates come from per-ticket sizing once `feature` kicks this off and `to-issues`/`build` run.
+
+| Layer    | Ballpark effort | Key drivers |
+|----------|------------------|-------------|
+| Backend  | e.g. S / M / L   | schema/API work surfaced below |
+| Frontend | e.g. S / M / L   | components + states surfaced below |
+| DevOps   | e.g. S / M / L   | infra/routing surfaced below |
+
+**Overall:** e.g. S / M / L — one line on what would move this up or down a size.
+
+## Decision tree
+
+For each question: the question asked, your recommended answer, and the answer the team chose (with a one-line reason if it diverged from the recommendation).
+
+1. **[Question]** — Recommended: [X]. Chosen: [Y]. [Why, if different.]
+
+## Multi-layer dependencies
+
+- **Backend:** schema/API implications surfaced during the interview.
+- **Frontend:** components, views, and states implicated.
+- **DevOps:** infra, routing, or env var changes implicated.
+
+## UX & edge cases for design
+
+Empty states, loading sequences, fallback experiences the designer must account for — carry these into the design-tracking issue `feature` creates next.
+
+## Open items
+
+Anything the team couldn't resolve in this sync — flag it so it doesn't silently drop before `feature` kicks this off.
+```

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: qa
+description: Run a structured, multi-pass QA review — on a single slice branch or standalone bugfix branch right after `build` hands it off, or on a feature's integration branch end-to-end before it merges into dev. Checks deviations from acceptance criteria, security, performance, correctness/maintainability, and integration, then loops fix → re-review until clean or capped. Use after build finishes a slice or bug fix, or before merging a feature's integration branch into dev.
+allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue edit:*), Bash(gh pr view:*), Bash(gh pr comment:*), Bash(git diff:*), Bash(git log:*), Bash(git branch:*), Bash(git fetch:*)
+---
+
+Review a diff against the acceptance criteria it's meant to satisfy, across five passes: deviations, security, performance, correctness & maintainability, and integration. This skill never fixes code and never merges anything — findings go back to whoever owns the code (`build`, for a slice) or to the user; a clean result unblocks the next step (opening a PR, or merging the integration branch to `dev`) without performing it.
+
+## 1. Determine scope
+
+Three modes, auto-detected from what's being reviewed:
+
+- **Slice-level**: a single issue (backend/frontend/devops label, linked to an epic) and its slice branch — this is what `build` just produced for a feature. Diff is that slice branch against the integration branch it branched from.
+- **Bugfix-level**: a standalone bug issue (`bug` label, no epic reference — typically from the `bug` skill) and its `fix/<slug>` branch. Diff is that branch against `dev` directly.
+- **Feature-level**: a whole feature's integration branch, reviewed end-to-end against `dev` before it merges — this is the "Feature validated end-to-end against the PRD acceptance criteria" line in the epic's Definition of Done that nothing else in this pipeline does.
+
+If the user gives an issue number labeled `bug` with no epic reference, treat it as bugfix-level. If they give an issue labeled backend/frontend/devops linked to an epic, or a slice branch matching `feat/<feature-branch>/<task>`, treat it as slice-level. If they give an epic number, a feature slug, or the bare integration branch name (`feat/<feature-branch>`), treat it as feature-level. If they gave nothing more specific than "review my changes," check `git branch --show-current`, `gh issue list`, and any open PR for the current branch — that's usually enough to resolve scope without asking. Only ask if the repo state genuinely doesn't disambiguate it, and when you do, offer the specific candidates you found rather than a generic "which one?".
+
+## 2. Gather acceptance criteria and the diff
+
+- **Slice-level**: read the issue's "Acceptance criteria" section. Diff = `git diff <integration-branch>...<slice-branch>`.
+- **Bugfix-level**: read the bug issue's "Acceptance criteria" (reproduction no longer occurs, regression test exists). Diff = `git diff dev...<fix-branch>`.
+- **Feature-level**: read the epic issue to find the integration branch and every child issue; fetch each child issue's "Acceptance criteria" — the full set is what "end-to-end" means here. Diff = `git diff dev...<feature-branch>`.
+
+Also read the `CLAUDE.md` of every top-level project directory the diff touches (same discovery approach as `build` step 2) — several of the passes below check the diff against conventions documented there, not against generic best practice.
+
+## 3. Run the five review passes
+
+Go through the diff once per pass below. Don't blend them into one generic read-through — each pass has a different failure mode it's looking for, and reading with one question in mind at a time catches things a single pass misses. For every finding, record: severity (**Critical** / **High** / **Medium** / **Low**), file:line, and a one-line explanation of the concrete failure it causes (not just "this looks off").
+
+<pass name="Deviations">
+Compare the diff against every acceptance criterion gathered in step 2. Flag anything not implemented, partially implemented, implemented differently than specified without a documented reason, or silently descoped. This is the pass generic code review skips — it's specific to this pipeline having real, structured acceptance criteria to check against.
+</pass>
+
+<pass name="Security">
+Injection risks (SQL/command/template), missing authn/authz checks on new endpoints or actions, secrets or credentials committed in code or config, unsafe deserialization, unvalidated input crossing a trust boundary (client input, external API responses, file uploads), and any new dependency worth flagging for provenance.
+</pass>
+
+<pass name="Performance">
+N+1 queries, unbounded loops or payloads over collections that can grow, missing pagination or indexes on new queries, blocking I/O on a hot/request path, and missing caching where the surrounding code already establishes that pattern.
+</pass>
+
+<pass name="Correctness & maintainability">
+Logic bugs, unhandled edge cases and error paths, dead code introduced or left behind, naming/structure inconsistent with the conventions documented in the touched directory's `CLAUDE.md`, and test coverage that doesn't actually exercise the acceptance criteria it claims to (shallow assertions, tests that would pass even if the feature were broken).
+</pass>
+
+<pass name="Integration">
+Slice-level: does this change conflict with or break other code paths, contracts, or tests already in the repo. Feature-level: do the slices' contracts actually line up with each other — does the frontend's API usage match what the backend slice actually returns, do devops prerequisites (env vars, provisioned infra) actually exist for what backend/frontend assume, are there gaps between slices that only show up when they're combined.
+</pass>
+
+## 4. Handle findings — fix/re-review loop
+
+If all five passes come back clean (or only Low/informational findings), skip to step 5.
+
+If Critical/High findings surfaced: report them grouped by pass, then ask whether to loop — hand the findings back to whoever owns the code (`build`, if this is a slice still in flight; otherwise the user) to fix, then re-run all five passes on the updated diff. Cap this at 3 automatic loops; if it's still not clean after that, stop and hand the full finding history to the user rather than looping indefinitely — a review that never converges is telling you something the loop itself can't fix.
+
+## 5. Report and unblock the next step
+
+- **Slice-level, clean**: tell the user this slice is ready for its PR into the integration branch. Don't open the PR — that's `build`'s handoff, not this skill's.
+- **Bugfix-level, clean**: tell the user this fix is ready for its PR directly into `dev`. Don't open the PR.
+- **Feature-level, clean**: offer to check off "Feature validated end-to-end against the PRD acceptance criteria" on the epic issue (`gh issue edit`) once the user confirms, and tell them the integration branch is ready to merge into `dev`. Merging it is out of scope here, same as it is for `feature` and `build`.
+- **Any scope, not clean after the loop cap**: report the outstanding findings by severity and stop — don't tick anything or imply readiness.
+
+Summarize: scope reviewed, findings per pass, number of fix/re-review loops run, and the final verdict.

--- a/.claude/skills/to-issues/SKILL.md
+++ b/.claude/skills/to-issues/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: to-issues
+description: Break an already-grilled, design-signed-off PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices, added to the epic that `feature` already created. Use when user wants to convert a PRD into issues, create implementation tickets, or break down work into issues, after the feature's design-tracking issue has closed.
+allowed-tools: Bash(gh api graphql:*), Bash(gh repo view:*), Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh issue edit:*)
+---
+
+Break the PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets), and add them to the epic that `feature` already set up for this feature.
+
+## Process
+
+### 1. Gather the PRD, epic, and design issue
+
+If the user passes a GitHub Discussions URL or discussion number, fetch the PRD body from it:
+
+```bash
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    discussion(number:$number){ title body }
+  }
+}' -f owner="OWNER" -f repo="REPO" -F number=NUMBER
+```
+
+Otherwise, work from whatever PRD content is already in the conversation context.
+
+This skill runs after `feature` has already created the epic and design issue for this feature — find them rather than creating a fresh epic. If the user gives an epic number, use it directly (`gh issue view NN`); otherwise search for the `epic` issue whose title matches the feature name (`gh issue list --label epic --state all`). Read the epic body to find the integration branch name and the design issue number.
+
+### Check design sign-off
+
+Fetch the design issue (`gh issue view NN --json state,body`). If it's still open, stop and tell the user dev tickets can't be cut until the design issue is closed with real Figma frame links — this is the whole point of moving design onto its own issue instead of a PRD placeholder. If the user explicitly wants to proceed anyway (e.g. backend-only work that doesn't touch UI), confirm that with them before continuing.
+
+Once closed, read the Figma frame links from the design issue's body — that's the source of truth for anchoring, not the PRD.
+
+### 2. Explore the codebase
+
+If you haven't already, explore the repo to understand the current state of the code. Issue titles and descriptions should use the project's domain vocabulary and respect any existing architectural patterns.
+
+### 3. Draft vertical slices
+
+Break the PRD into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL layers end-to-end — NOT a horizontal slice of one layer.
+
+<vertical-slice-rules>
+- Group by **user action** — one issue per distinct thing a user can do. Map directly to user story groups in the PRD.
+- Each slice delivers a complete path through every layer (schema, API, UI, tests) for that action
+- A completed slice is demoable or verifiable on its own
+- Label each slice as **frontend**, **backend**, or **devops**
+- The "one issue per user action" rule applies to **frontend and backend equally**. Never bundle multiple user actions into one backend issue — each action gets its own backend issue and its own frontend issue.
+- When a user action requires both layers, produce two issues: one backend + one frontend. The frontend issue is blocked by its backend counterpart.
+- Use layer-specific vocabulary in titles: backend issues use words like "endpoint", "API", "schema", "policy"; frontend issues use "page", "form", "component", "view"; devops issues use "provision", "pipeline", "env var", "deploy".
+- Schema / content type setup and ownership policy are infrastructure that other issues depend on — treat them as their own backend issue(s) that everything else blocks on, not something to bundle into the first CRUD endpoint.
+- **Isolate DevOps work into its own tickets.** Infrastructure provisioning, migrations, and environment-variable setup are never a line item inside a backend or frontend issue — they get their own devops issue(s) that the relevant backend/frontend slices are blocked by. This is what lets a systems engineer pick up devops work in parallel instead of waiting on backend/frontend to surface it mid-implementation.
+- **Group edits by entity, not by field.** If the PRD lists multiple editable fields on the same entity (e.g. edit title, edit description, edit status), collapse them into a single issue: "Edit [Entity]". Do NOT create one issue per field.
+- **Never merge create operations.** Each "Create [Entity]" is its own issue — creation involves schema, validation, and defaults that are distinct per entity.
+- **Never merge different user actions** even if they touch the same code. "Complete to-do" and "Delete to-do" are separate issues because they are separate things a user does.
+</vertical-slice-rules>
+
+### Figma anchoring
+
+Copy the relevant frame link from the closed design issue directly into each frontend issue's body under a `## Design` heading — the engineer shouldn't have to hunt through a separate issue for it.
+
+### 4. Confirm with the user
+
+Present the proposed breakdown as a numbered list. For each slice show:
+- **Title**
+- **Layer**: frontend / backend / devops
+- **Blocked by**: other slices that must complete first
+- **User stories covered**
+- **Acceptance criteria**: the actual draft criteria, not just a placeholder — this is what the user is really approving, since it's what `build` and `qa` will hold the implementation to.
+
+Ask the user if the granularity is right, dependencies are correct, and the acceptance criteria actually capture what "done" means for each slice. Iterate until approved.
+
+### 5. Publish the issues
+
+For each approved slice, create a GitHub issue using the template below. Publish in dependency order (blockers first — devops issues typically go first) so you can reference real issue numbers in the "Blocked by" field. Note the integration branch (found in step 1) in each issue's body so `build` can discover it later.
+
+```bash
+gh issue create --title "TITLE" --body "BODY" --label "frontend|backend|devops"
+```
+
+### 6. Add the new issues to the epic
+
+`feature` already created the epic with empty Backend/Frontend/DevOps groups — edit its body to fill them in with the issues just published, grouped by layer, same as the Design group already there:
+
+```bash
+gh issue edit EPIC_NUMBER --body "UPDATED_BODY"
+```
+
+<issue-template>
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation. Avoid specific file paths or code snippets — they go stale fast.
+
+## Design
+
+(Frontend issues only.) The Figma frame link(s) copied from the feature's design issue for this slice. Omit this heading entirely for backend/devops issues.
+
+## Acceptance criteria
+
+Each criterion must be testable and specific enough that someone could check it off without reading the code: name the input/action, the system's response, and what "done" looks like. "Handles errors gracefully" is not acceptable — say which error and what the observable handling is. Cover, at minimum:
+
+- The happy path for this slice's user action.
+- At least one edge case or failure mode (empty state, invalid input, large/boundary input, permission denied — whatever's actually relevant to this slice).
+- Any non-functional constraint the PRD or grill-me report called out for this slice (performance threshold, security check, specific empty/loading/error state) — don't drop these silently just because they're not the primary behavior.
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- #issue-number (if any), or "None — can start immediately"
+
+## Final Engineering Estimate
+
+_(engineer fills this in right before cutting the branch with `build` — leave blank at publish time)_
+
+---
+Part of #EPIC · integration branch: `feat/<feature-branch>`
+
+</issue-template>

--- a/.claude/skills/to-prd/SKILL.md
+++ b/.claude/skills/to-prd/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: to-prd
+description: Turn the current conversation context into a PRD and publish it to GitHub Discussions under the PRD category. Use when user wants to create a PRD from the current context.
+allowed-tools: Bash(gh api graphql:*), Bash(gh repo view:*)
+---
+
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain vocabulary throughout the PRD.
+
+2. Write the PRD using the template below.
+
+3. Post it to GitHub Discussions in the "PRD" category:
+   - Run `gh repo view --json nameWithOwner` to get owner and repo name.
+   - Query discussion categories and find "PRD" by name:
+   ```bash
+   gh api graphql -f query='query($owner:String!,$repo:String!){
+     repository(owner:$owner,name:$repo){
+       id
+       discussionCategories(first:20){nodes{id name}}
+     }
+   }' -f owner="OWNER" -f repo="REPO"
+   ```
+   - Create the discussion using the repository id and the "PRD" category id from the query above:
+   ```bash
+   gh api graphql -f query='mutation($repoId:ID!,$catId:ID!,$title:String!,$body:String!){
+     createDiscussion(input:{repositoryId:$repoId,categoryId:$catId,title:$title,body:$body}){
+       discussion { url }
+     }
+   }' -f repoId="REPO_ID" -f catId="CATEGORY_ID" -f title="TITLE" -f body="BODY"
+   ```
+
+4. Report the discussion URL to the user, and call out that the `## Design & User Experience` section is a placeholder — actual design sign-off happens on a dedicated design-tracking issue that `feature` creates when this feature kicks off (after `grill-me`), not in this discussion. `grill-me` reads the PRD from this discussion; `to-issues` reads Figma frames from the design issue instead.
+
+## PRD template
+
+Fill in every section below using what you already know from the conversation and codebase — don't leave a section as boilerplate if you have enough context to write it for real.
+
+```markdown
+# [Feature Name]
+
+## Problem
+
+What's broken or missing today, and for whom. Ground this in the actual codebase/product, not a generic pain point.
+
+## Goals
+
+- Goal 1
+- Goal 2
+
+## Non-goals
+
+What this explicitly does not cover, to keep scope bounded.
+
+## User stories
+
+- As a [user type], I want to [action], so that [outcome].
+- (Repeat — cover every distinct action a user can take. `to-issues` will map these 1:1 to vertical-slice tickets later, so be thorough here rather than terse.)
+
+## Design & User Experience
+
+> ⏳ **Pending design sign-off**, tracked separately. Once this PRD is grilled, `feature` creates a dedicated design-tracking issue for Figma sign-off — `to-issues` reads frame links from that issue, not from this section.
+
+## Functional requirements
+
+Numbered, testable requirements derived from the user stories above.
+
+1. Requirement 1
+2. Requirement 2
+
+## Success metrics
+
+How you'll know this shipped successfully.
+
+## Open questions
+
+Anything genuinely unresolved — surface it here rather than silently guessing. `grill-me` is where the team resolves these.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`yml-change-webhook-trigger` is a GitHub Action (published to the Marketplace by wearemiew) that:
+1. Detects which `.yml`/`.yaml` files changed in a push or pull request.
+2. Parses each changed file for a `x-update-webhooks` array of URLs.
+3. POSTs a JSON payload (source, file, repo, ref, sha, timestamp) to each unique webhook URL, with retries and bounded concurrency.
+4. Writes a Markdown report to `$GITHUB_STEP_SUMMARY` and exposes `changed_files` / `webhook_results` as action outputs.
+
+It lets other repos declare "notify this URL when my config changes" directly inside their YAML files instead of wiring bespoke CI glue.
+
+## Commands
+
+```bash
+npm test              # run the Jest suite (__tests__/**/*.test.js)
+npm run test:watch    # watch mode
+npm run lint          # eslint .
+npm run format        # prettier --write on js/json/yml/yaml
+npm run build         # ncc-bundle src/index.js -> dist/index.js (+ dist/package.json)
+```
+
+Run a single test file or case directly with Jest (bypassing the npm alias if you want extra flags):
+```bash
+NODE_ENV=test npx jest --config jest.config.cjs __tests__/parse-yaml.test.js
+NODE_ENV=test npx jest --config jest.config.cjs -t "should extract webhook URLs"
+```
+`NODE_ENV=test` matters: `@actions/core` is mocked via `moduleNameMapper` (`__mocks__/@actions/core.js`) and the mock/jest setup assumes the test env.
+
+## Architecture
+
+Entry point declared in [action.yml](action.yml) is `dist/index.js` (Node 20 runtime), but **`dist/` is git-ignored and must never be hand-edited** — it's a ncc-bundled artifact only committed by CI during the release flow (see below). Local development happens entirely in `src/`; run `npm run build` if you need to smoke-test the actual bundled entry point.
+
+Pipeline, wired together in [src/index.js](src/index.js):
+1. **[src/detect-changes.js](src/detect-changes.js)** — shells out to `git diff --name-only` to list changed files, filtered to `.yml`/`.yaml`. Branches on `GITHUB_EVENT_NAME`: for `pull_request` it diffs against `origin/<base_ref or GITHUB_BASE_REF or main>...HEAD`; for `push` it prefers `GITHUB_EVENT_BEFORE..GITHUB_SHA`, falling back to `HEAD^` or (on a repo's first commit) the files added in `HEAD`.
+2. **[src/parse-yaml.js](src/parse-yaml.js)** — reads each changed file, `js-yaml`-parses it, and pulls out `x-update-webhooks` entries that start with `http`. This is the file-format contract other repos rely on (see `examples/*.yml`).
+3. **[src/execute-webhooks.js](src/execute-webhooks.js)** — de-dupes webhook URLs (first file wins for reporting), then POSTs them in batches of 5 concurrent requests via axios, with exponential-backoff retry (3 attempts: 1s/2s/4s). URLs are host+truncated-path masked (`maskUrl`) before ever being logged or put in outputs, since they can contain sensitive tokens.
+4. Back in `index.js`, `generateSummaryReport` renders a Markdown table of results into `$GITHUB_STEP_SUMMARY` (skipped if that env var is unset, e.g. running outside Actions).
+
+Errors at any stage are caught and reported via `core.setFailed`/`core.warning` rather than throwing — the action is expected to degrade gracefully (e.g., zero changed files or zero webhooks just exit early with outputs set).
+
+## Release automation
+
+Versioning and publishing are fully automated via chained workflows (see [docs/workflows.md](docs/workflows.md) for the full diagram):
+- `.github/workflows/test.yml` — runs on push/PR touching `src/**`, YAML, or package files; also self-tests the action on `main`.
+- `.github/workflows/auto-version.yml` — on merge to `main`, bumps `package.json` per Conventional Commits (`fix:`→patch, `feat:`→minor, `BREAKING CHANGE:`/`feat!:`→major).
+- `.github/workflows/release-workflow.yml` — builds, force-commits `dist/` (normally git-ignored), creates the GitHub release, and updates floating `vN`/`vN.M` tags.
+- `.github/workflows/publish.yml` — runs on release creation to finalize the Marketplace listing.
+
+Because of this, commit messages must follow Conventional Commits for automatic version bumps to work, and `dist/` is intentionally absent from feature branches — don't add it to a PR by hand.
+
+Note: `auto-version.yml` and `release-workflow.yml` are wired to the `main` branch, but day-to-day work happens on `dev` (the repo's actual default branch — see Git workflow below). Keep this in mind if release automation ever needs touching.
+
+## Git workflow
+
+- Never commit directly to `dev` or `main`.
+- Always create a separate branch and open a PR targeting `dev`. Prefixes: `feat/…`, `fix/…`, `chore/…`, `ci/…`, `docs/…`, `refactor/…`, `test/…`, `perf/…`, `style/…`, `revert/…` — these mirror the Conventional Commits types below.
+- Ask the user before committing code to any branch.
+- Before committing, show the user the test results (`npm test`). If everything passes, proceed with the commit. If anything fails, do not commit — ask the user how they want to resolve the failure.
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/) — this isn't just style, `auto-version.yml` parses these to decide the version bump (see Release automation above):
+
+```
+<type>(<optional scope>): <short description>
+```
+
+Allowed types: `feat`, `fix`, `chore`, `ci`, `docs`, `refactor`, `test`, `perf`, `style`, `revert`
+
+Examples:
+- `feat: add retry backoff cap to webhook execution`
+- `fix: handle empty x-update-webhooks array`
+- `chore: bump js-yaml to 5.2.2`
+- `ci: cache npm dependencies in test workflow`
+
+There is no PR auto-labeling configured in this repo (no `.github/labeler.yml` or labeler workflow) — branch prefixes above are for commit-type/version-bump consistency, not automated labeling.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,15 @@ npm install
 ### Testing
 
 ```bash
-npm test
+npm test          # run the Jest suite
+npm run test:watch
+```
+
+### Linting & Formatting
+
+```bash
+npm run lint      # eslint .
+npm run format    # prettier --write on js/json/yml/yaml
 ```
 
 ### Local Development
@@ -165,6 +173,8 @@ The `dist` directory containing the compiled code is not checked into the reposi
 3. Test your changes with `npm test`
 
 The `dist` directory is only built and included in the repository when a release is created.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution workflow, and [docs/workflows.md](docs/workflows.md) for how the CI/CD pipeline fits together.
 
 ### Release Process
 
@@ -200,4 +210,4 @@ Contributions are welcome! Please open an issue or submit a pull request.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License (see the `license` field in `package.json`).


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` documenting the repo's purpose, architecture, release automation, and git/commit conventions for Claude Code sessions.
- Add a lightweight PRD-to-PR skill pipeline under `.claude/skills/`: `bug`, `build`, `feature`, `grill-me`, `qa`, `to-issues`, `to-prd`.
- Add guard hooks under `.claude/hooks/`: `protect-branches.sh`, `actionlint-check.sh`, `ts-typecheck.sh`.
- Expand README's Testing section (lint/format commands) and link out to `CONTRIBUTING.md` and `docs/workflows.md`.
- Add a few read-only permission rules to `.claude/settings.local.json` picked up during local Claude Code sessions.

## Test plan
- [x] `npm test` passes (3/3) after a clean `npm install`
- [x] Confirmed `dist/index.js` / `package-lock.json` rebuild side-effects from local install were **not** included in this PR