### PR TITLE
chore(ci): scope GITHUB_TOKEN to read-only for test and security-audit workflows

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,6 +13,8 @@ jobs:
   audit:
     runs-on:
       labels: [test]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
     # runs-on: ubuntu-latest
     runs-on:
       labels: [test]
+    permissions:
+      contents: read
     strategy:
       matrix:
         # node-version: [18.x, 20.x]
@@ -86,6 +88,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to `test.yml` (both `test` and `lint` jobs) and `security-audit.yml`.
- Neither workflow needs write access: checkout, install, test, lint, `npm audit`, OWASP Dependency-Check, and artifact upload are all read-only operations against the repo.
- Companion to a repo-settings change (already applied): `default_workflow_permissions` flipped from `write` to `read` org/repo-wide. These two workflows were the only ones without their own scoped `permissions:` block (the other 4 CI workflows already declare `contents`/`pull-requests`/`packages` write explicitly, only where actually needed), so they were silently inheriting the broad default.

Closes #145

## Context
Prompted by a security review of the repo's public-facing permissions after an external fork (PR #118) opened a PR against this repo. That PR turned out to be a harmless stale duplicate of already-merged dependency bumps — not malicious — but the review surfaced this as a real, independent hardening gap. Also applied in the same pass (not part of this diff, done via repo settings/API):
- Branch protection enabled on `main` and `dev` (1 required approving review, required passing status checks, no force-push, no deletion).
- PR #118 closed with an explanation.

## Test plan
- [x] Both changed files parse as valid YAML
- [x] Confirmed via reading both workflows line-by-line that no step in either requires write access to repo contents, PRs, issues, or packages