### PR TITLE
chore(ci): migrate action and workflows to Node 24 runtime

### DIFF
--- a/.github/actions/version-detector/action.yml
+++ b/.github/actions/version-detector/action.yml
@@ -6,5 +6,5 @@ outputs:
   bump_type:
     description: "Determined bump type (major, minor, patch, none)"
 runs:
-  using: "node20"
+  using: "node24"
   main: "index.js"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
       - "dependencies"
       - "automerge"
     versioning-strategy: auto
-    
+    ignore:
+      # @actions/core@3.x is ESM-only; this repo's CommonJS source and ncc
+      # build break during `npm ci` (prepare -> ncc build fails to resolve
+      # the package's `exports` map). See issue #136 / PR #115.
+      - dependency-name: "@actions/core"
+        versions: [">=3.0.0"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       # Determine version bump using a proven action

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       # Install dependencies

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -382,7 +382,7 @@ jobs:
         if: steps.setup-release.outputs.should_release == 'true' && steps.setup-release.outputs.version != 'unknown'
         uses: actions/setup-node@v7
         with:
-          node-version: "20" # Specify Node.js version
+          node-version: "24" # Specify Node.js version
           cache: "npm" # Cache npm dependencies
 
       # Step 9: Install dependencies

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Audit dependencies
         run: npm audit --audit-level=moderate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,7 @@ jobs:
       labels: [test]
     strategy:
       matrix:
-        # node-version: [18.x, 20.x]
-        node-version: [20.x]
+        node-version: [24.x]
       fail-fast: false
 
     steps:
@@ -77,9 +76,9 @@ jobs:
       # - name: Build action
       #   run: npm run build
 
-      # Self-test the action (only on push to main and only for Node 20)
+      # Self-test the action (only on push to main and only for Node 24)
       - name: Self-test
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.node-version == '20.x'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.node-version == '24.x'
         uses: ./
         with:
           base_ref: ""
@@ -93,7 +92,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For a detailed look at webhook triggers during this workflow run. Total changed 
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 24+
 - npm or yarn
 
 ### Setup

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ outputs:
     description: "JSON array of webhook execution results with file mappings."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "globals": "^17.8.0",
         "jest": "^30.4.2",
         "prettier": "^3.9.6"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.9.4",
   "description": "GitHub Action to detect YML changes and trigger webhooks",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "ncc build src/index.js -o dist && node -e \"require('fs').writeFileSync('dist/package.json', JSON.stringify({type: 'commonjs'}))\"",
     "test": "cross-env NODE_ENV=test jest --config jest.config.cjs --passWithNoTests",


### PR DESCRIPTION
## Summary
- Migrate `action.yml` and the internal `version-detector` composite action from `node20` to `node24`.
- Migrate all 6 CI workflows (`test.yml`, `auto-version.yml`, `release-workflow.yml`, `auto-merge-dependabot.yml`, `publish.yml`, `security-audit.yml`) from Node 20 to Node 24.
- Add `engines.node: ">=24"` to `package.json` and update the README prerequisite.
- Defer `@actions/core` v3 (ESM-only, breaks the `ncc`/CommonJS build via the `prepare` script) rather than migrating now — added a Dependabot `ignore` rule for `@actions/core >=3.0.0`. PR #115 closed with the documented failure reason instead of merging.

## Why
GitHub requires Node 24 as the minimum Actions runtime as of 2026-06-02 (already past), and will fully remove Node 20 from runners on 2026-09-16.

## Notes
- No source code changes — `dist/index.js` stays CommonJS; `runs.using: node24` only selects the runner's embedded Node binary, which fully supports CJS.
- `test.yml`'s self-test conditional (`matrix.node-version == '20.x'` → `'24.x'`) was updated too — easy to miss, and missing it would silently stop the self-test step from ever running again.
- **Pre-merge check needed**: `test`, `auto-merge-dependabot`, `security-audit`, and `publish`'s `notify` job run on a self-hosted runner (`labels: [test]`), not `ubuntu-latest`. GitHub requires runner v2.327.0+ to execute `node24`-runtime actions. Please confirm the runner is updated before merging, or watch these jobs' first run closely.
- Found and confirmed pre-existing on `dev` (unrelated to this change, not fixed here): `npm run lint` currently fails with `Cannot find package 'globals'` — `eslint.config.mjs` imports it but it's missing from `package.json`. Worth its own issue.

Closes #136

## Test plan
- [x] `npm install && npm run build && npm test` locally under Node 24 — build succeeds, 3/3 tests pass
- [x] All changed YAML files validated as parseable
- [x] Confirmed no remaining `node20`/`"20"`/`[20.x]` references anywhere in the repo