### PR TITLE
ci: run Test Action workflow on PRs targeting dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ on:
       - "jest.config.cjs"
     branches:
       - main
+      - dev
       - "feature/**"
 
 # Add concurrency control to prevent multiple workflows from running simultaneously

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,8 @@ on:
   push:
     paths:
       - "src/**"
-      - "**.y{a,}ml"
+      - "**.yml"
+      - "**.yaml"
       - "package*.json"
       - "jest.config.cjs"
     branches-ignore:
@@ -20,7 +21,8 @@ on:
   pull_request:
     paths:
       - "src/**"
-      - "**.y{a,}ml"
+      - "**.yml"
+      - "**.yaml"
       - "package*.json"
       - "jest.config.cjs"
     branches:


### PR DESCRIPTION
## Summary
Two compounding bugs in `test.yml`'s triggers, both fixed here:

1. `pull_request.branches` only matched `main` and `feature/**`, so PRs targeting `dev` (this repo's actual day-to-day integration branch) never triggered CI pre-merge.
2. The `**.y{a,}ml` paths pattern relies on brace expansion, which GitHub Actions path filters do not support - it has never matched any real file. Replaced with explicit `**.yml` / `**.yaml` entries.

Discovered while enabling branch protection with required `test (24.x)`/`lint` status checks on `dev`: those checks could never be satisfied for a `dev`-targeted PR touching only workflow YAML, since the workflow never ran at all - which is exactly what this PR itself is, making it a good end-to-end test of the fix.

Closes #143
Closes #146

## Test plan
- [x] YAML validated
- [x] This PR itself targets `dev` and touches only `.github/workflows/test.yml` - its own CI run is the verification that both fixes work together