### PR TITLE
fix: release workflow checks out dev instead of main, version bump silently skipped

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -51,7 +51,11 @@ jobs:
           git-push: true
           git-message: "chore(release): {version}"
           skip-tag: false
-          skip-on-empty: true
+          # false: always commit/tag/push when a bump type is determined, even if the
+          # rendered changelog body comes out empty (e.g. a merge whose commits are
+          # mostly chore/ci/build types the Angular preset hides from the changelog).
+          # Previously true, which silently skipped the version bump entirely - see #152.
+          skip-on-empty: false
 
       # Update version in package.json if bump type is not none
       - name: Update package.json version

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: main # Always release from main, regardless of trigger type - the repo's default branch is dev, and workflow_run events otherwise default to it
           fetch-depth: 0 # Fetch full history for better commit analysis
 
       # Step 4: Manual version bump (only for workflow_dispatch trigger)


### PR DESCRIPTION
## Summary

Two bugs in the release automation, both found via the real failed release run (id 30280249311) that followed merging PR #105 into `main` today:

1. **`release-workflow.yml` checked out `dev` instead of `main`.** Its checkout step had no explicit `ref:`, so for `workflow_run`-triggered runs `actions/checkout` defaulted to `github.ref`, which resolves to the repo's default branch (`dev`, not `main`). The job then tried to force-commit a `dist/` rebuild directly onto `dev` and was correctly rejected by today's new branch protection: `remote: error: GH006: Protected branch update failed for refs/heads/dev`. Before branch protection existed, this same misdirected push would have silently succeeded every release cycle - almost certainly why `dev`'s committed `dist/index.js` was found stale and oddly out of sync with `src/`. Fixed by pinning `ref: main` explicitly.

2. **The version bump commit was silently skipped.** `auto-version.yml` correctly determined a patch bump was warranted (1.9.4 → 1.9.5) but aborted before committing/pushing anything because `skip-on-empty: true` considered the rendered changelog "empty" (real `fix:` commits exist in range, but the Angular preset hides several commit types from the changelog body). Downstream, `release-workflow.yml`'s fallback logic then tried to re-release v1.9.4 - already shipped back in September - instead of the correct new version. Fixed by setting `skip-on-empty: false`, so the commit/tag/push always happens once a bump type is determined, independent of changelog rendering quirks.

Closes #151
Closes #152

## Test plan
- [x] Both changed files validated as parseable YAML
- [x] `npm test` passes (3/3), `npm run lint` clean (unrelated to these changes, confirming nothing else broke)
- [ ] Next actual merge to `main` should produce a correctly-versioned, correctly-targeted release - can't be fully verified until then