### PR TITLE
fix: release workflows push using RELEASE_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -31,7 +31,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN (a PAT with Write role) is required, not GITHUB_TOKEN: main's
+          # ruleset requires PRs for everyone except the Write-role bypass - GITHUB_TOKEN
+          # authenticates as the github-actions bot, which has no bypass path available.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       # Setup Node.js environment
       - name: Setup Node.js
@@ -45,7 +48,7 @@ jobs:
         id: conventional-commits
         uses: TriPSs/conventional-changelog-action@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.RELEASE_TOKEN }}
           skip-version-file: false
           skip-commit: false
           git-push: true

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -88,6 +88,10 @@ jobs:
         with:
           ref: main # Always release from main, regardless of trigger type - the repo's default branch is dev, and workflow_run events otherwise default to it
           fetch-depth: 0 # Fetch full history for better commit analysis
+          # RELEASE_TOKEN (a PAT with Write role) is required, not GITHUB_TOKEN: main's
+          # ruleset requires PRs for everyone except the Write-role bypass - GITHUB_TOKEN
+          # authenticates as the github-actions bot, which has no bypass path available.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       # Step 4: Manual version bump (only for workflow_dispatch trigger)
       # If the workflow is triggered manually, this step bumps the version in package.json


### PR DESCRIPTION
## Summary
`main`'s ruleset requires a PR for everyone, and the only available bypass actor types in this org are Roles (Org/Repo admin, Maintain, Write), Deploy keys, and Teams — no App/Integration bypass exists for the built-in `github-actions` bot. So `GITHUB_TOKEN` (which authenticates as that bot) can never push directly to `main`, regardless of ruleset config.

Switched `auto-version.yml`'s checkout token and `TriPSs/conventional-changelog-action`'s `github-token`, plus `release-workflow.yml`'s checkout token, to a new `RELEASE_TOKEN` secret — a PAT belonging to an account with `Write` role, which the ruleset's bypass list now exempts from the PR requirement.

## Test plan
- [x] Both changed files validated as parseable YAML
- [ ] Next real merge to `main` should let the release bot push its version-bump/dist-build commits directly, without hitting `GH006: Protected branch update failed`