### PR TITLE
chore: sync version past orphaned v1.9.5 tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yml-change-webhook-trigger",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yml-change-webhook-trigger",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yml-change-webhook-trigger",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "GitHub Action to detect YML changes and trigger webhooks",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
Bumps package.json to 1.9.5 so the next automated release computes 1.9.6 instead of colliding with the orphaned v1.9.5 tag already on the remote from an earlier failed attempt.